### PR TITLE
feature/#14-save raw data after crawling

### DIFF
--- a/src/main/java/com/example/yogijosim/common/BaseTimeEntity.java
+++ b/src/main/java/com/example/yogijosim/common/BaseTimeEntity.java
@@ -1,0 +1,17 @@
+package com.example.yogijosim.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+	@CreatedDate
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/yogijosim/config/JpaConfig.java
+++ b/src/main/java/com/example/yogijosim/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.example.yogijosim.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/example/yogijosim/data/application/CrawledDataController.java
+++ b/src/main/java/com/example/yogijosim/data/application/CrawledDataController.java
@@ -1,0 +1,24 @@
+package com.example.yogijosim.data.application;
+
+import com.example.yogijosim.data.application.service.CrawledDataService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class CrawledDataController {
+	private final CrawledDataService crawledDataService;
+
+	@PostMapping("/crawled-data")
+	public ResponseEntity<Long> saveData(@Valid @RequestBody CrawledDataSaveRequestDto request){
+		Long savedDataId = crawledDataService.save(request);
+		return ResponseEntity.status(HttpStatus.CREATED).body(savedDataId);
+	}
+}

--- a/src/main/java/com/example/yogijosim/data/application/CrawledDataSaveRequestDto.java
+++ b/src/main/java/com/example/yogijosim/data/application/CrawledDataSaveRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.yogijosim.data.application;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record CrawledDataSaveRequestDto(
+	@NotEmpty
+	String sourceCommunity,
+
+	@NotEmpty
+	String sourceUrl,
+
+	@NotEmpty
+	String rawContent
+) {
+}

--- a/src/main/java/com/example/yogijosim/data/application/service/CrawledDataService.java
+++ b/src/main/java/com/example/yogijosim/data/application/service/CrawledDataService.java
@@ -1,0 +1,17 @@
+package com.example.yogijosim.data.application.service;
+
+import com.example.yogijosim.data.application.CrawledDataSaveRequestDto;
+import com.example.yogijosim.data.domain.CrawledData;
+import com.example.yogijosim.data.domain.CrawledDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CrawledDataService {
+	private final CrawledDataRepository crawledDataRepository;
+
+	public Long save(CrawledDataSaveRequestDto request) {
+		return crawledDataRepository.save(CrawledData.from(request));
+	}
+}

--- a/src/main/java/com/example/yogijosim/data/domain/CrawledData.java
+++ b/src/main/java/com/example/yogijosim/data/domain/CrawledData.java
@@ -1,0 +1,38 @@
+package com.example.yogijosim.data.domain;
+
+import com.example.yogijosim.common.BaseTimeEntity;
+import com.example.yogijosim.data.application.CrawledDataSaveRequestDto;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CrawledData extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "source_community", nullable = false)
+	private String sourceCommunity;
+
+	@Column(name = "source_url", nullable = false, unique = true)
+	private String sourceUrl;
+
+	@Lob
+	@Column(name = "raw_content", nullable = false, columnDefinition = "TEXT")
+	private String rawContent;
+
+	public static CrawledData from(CrawledDataSaveRequestDto request) {
+		return CrawledData.builder().
+			sourceCommunity(request.sourceCommunity())
+			.sourceUrl(request.sourceUrl())
+			.rawContent(request.rawContent())
+			.build();
+	}
+}

--- a/src/main/java/com/example/yogijosim/data/domain/CrawledDataRepository.java
+++ b/src/main/java/com/example/yogijosim/data/domain/CrawledDataRepository.java
@@ -1,0 +1,8 @@
+package com.example.yogijosim.data.domain;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrawledDataRepository {
+	Long save(CrawledData crawledData);
+}

--- a/src/main/java/com/example/yogijosim/data/persistence/CrawledDataJpaRepository.java
+++ b/src/main/java/com/example/yogijosim/data/persistence/CrawledDataJpaRepository.java
@@ -1,0 +1,7 @@
+package com.example.yogijosim.data.persistence;
+
+import com.example.yogijosim.data.domain.CrawledData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CrawledDataJpaRepository extends JpaRepository<CrawledData, Long> {
+}

--- a/src/main/java/com/example/yogijosim/data/persistence/CrawledDataRepositoryImpl.java
+++ b/src/main/java/com/example/yogijosim/data/persistence/CrawledDataRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.example.yogijosim.data.persistence;
+
+import com.example.yogijosim.data.domain.CrawledData;
+import com.example.yogijosim.data.domain.CrawledDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CrawledDataRepositoryImpl implements CrawledDataRepository {
+	private final CrawledDataJpaRepository crawledDataJpaRepository;
+
+	@Override
+	public Long save(CrawledData crawledData) {
+		return crawledDataJpaRepository.save(crawledData).getId();
+	}
+}

--- a/src/main/java/com/example/yogijosim/region/domain/Region.java
+++ b/src/main/java/com/example/yogijosim/region/domain/Region.java
@@ -1,11 +1,12 @@
 package com.example.yogijosim.region.domain;
 
+import com.example.yogijosim.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 @Getter
 @Entity
-public class Region {
+public class Region extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/yogijosim/subscription/domain/Subscription.java
+++ b/src/main/java/com/example/yogijosim/subscription/domain/Subscription.java
@@ -1,5 +1,6 @@
 package com.example.yogijosim.subscription.domain;
 
+import com.example.yogijosim.common.BaseTimeEntity;
 import com.example.yogijosim.region.domain.Region;
 import com.example.yogijosim.user.domain.User;
 import jakarta.persistence.*;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @Entity
 @Getter
-public class Subscription {
+public class Subscription extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/yogijosim/user/domain/User.java
+++ b/src/main/java/com/example/yogijosim/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.example.yogijosim.user.domain;
 
+import com.example.yogijosim.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity
 @Builder
-public class User {
+public class User extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- #14 

### 📝 작업 내용
- This PR introduces the foundational API for the data processing pipeline. It allows the crawler component to submit raw crawled data (community, URL, content) to the server for persistence.

- The saved data will be used in the next phase for GPT analysis. This completes the first issue for building the data processing pipeline.


### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

