### PR TITLE
feature/#26-create WebConfig to set CORS configuration

### DIFF
--- a/src/main/java/com/example/yogijosim/config/WebConfig.java
+++ b/src/main/java/com/example/yogijosim/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.example.yogijosim.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer{
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}
+


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- #26 

### 📝 작업 내용
- 로컬에서 api를 테스트하기 위해 일시적으로 localhost:3000에 CORS 접근을 허용합니다.

### 📷 스크린샷 (선택)


### 💬 리뷰 요구사항 (선택)

